### PR TITLE
Added dropHandler support via a drop view

### DIFF
--- a/CCNStatusItem Example/CCNStatusItem Example.xcodeproj/project.pbxproj
+++ b/CCNStatusItem Example/CCNStatusItem Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1782392C1AFBCEEB00D41AB3 /* CCNStatusItemDropView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1782392B1AFBCEEB00D41AB3 /* CCNStatusItemDropView.m */; };
 		6800FB481AEB486700942B4E /* ContentView2Controller.m in Sources */ = {isa = PBXBuildFile; fileRef = 6800FB461AEB486700942B4E /* ContentView2Controller.m */; };
 		6800FB491AEB486700942B4E /* ContentView2Controller.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6800FB471AEB486700942B4E /* ContentView2Controller.xib */; };
 		FD2CF54C1AE2E60A006F3D46 /* CCNStatusItemWindowConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FD2CF54B1AE2E60A006F3D46 /* CCNStatusItemWindowConfiguration.m */; };
@@ -23,6 +24,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1782392A1AFBCEEB00D41AB3 /* CCNStatusItemDropView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCNStatusItemDropView.h; sourceTree = "<group>"; };
+		1782392B1AFBCEEB00D41AB3 /* CCNStatusItemDropView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCNStatusItemDropView.m; sourceTree = "<group>"; };
 		6800FB451AEB486700942B4E /* ContentView2Controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentView2Controller.h; sourceTree = "<group>"; };
 		6800FB461AEB486700942B4E /* ContentView2Controller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContentView2Controller.m; sourceTree = "<group>"; };
 		6800FB471AEB486700942B4E /* ContentView2Controller.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ContentView2Controller.xib; sourceTree = "<group>"; };
@@ -108,6 +111,8 @@
 			children = (
 				FDA94B8F1A69F9D000EB4169 /* CCNStatusItem.h */,
 				FDA94B901A69F9D000EB4169 /* CCNStatusItem.m */,
+				1782392A1AFBCEEB00D41AB3 /* CCNStatusItemDropView.h */,
+				1782392B1AFBCEEB00D41AB3 /* CCNStatusItemDropView.m */,
 				FDA94B911A69F9D000EB4169 /* CCNStatusItemWindow.h */,
 				FDA94B921A69F9D000EB4169 /* CCNStatusItemWindow.m */,
 				FDA94B951A69F9D000EB4169 /* CCNStatusItemWindowBackgroundView.h */,
@@ -220,6 +225,7 @@
 				6800FB481AEB486700942B4E /* ContentView2Controller.m in Sources */,
 				FDA94B9D1A69F9D000EB4169 /* CCNStatusItemWindowController.m in Sources */,
 				FD9AC0621A4F74BC00129381 /* ContentViewController.m in Sources */,
+				1782392C1AFBCEEB00D41AB3 /* CCNStatusItemDropView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CCNStatusItem Example/CCNStatusItem Example/Base.lproj/MainMenu.xib
+++ b/CCNStatusItem Example/CCNStatusItem Example/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7531" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -674,9 +674,8 @@
         </menu>
         <window title="CCNStatusItem Example" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" frameAutosaveName="CCNStatusItemExampleWindow" animationBehavior="default" id="Jyi-cW-7II">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="100" y="568" width="480" height="562"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="Uqc-eN-Myc">
                 <rect key="frame" x="0.0" y="-1" width="480" height="562"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -712,7 +711,7 @@
                         </textFieldCell>
                     </textField>
                     <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fa5-ku-2Ud">
-                        <rect key="frame" x="76" y="284" width="343" height="25"/>
+                        <rect key="frame" x="76" y="284" width="343" height="26"/>
                         <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="10" maxValue="50" doubleValue="10" tickMarkPosition="above" numberOfTickMarks="40" allowsTickMarkValuesOnly="YES" sliderType="linear" id="E0I-93-1k7"/>
                         <connections>
                             <action selector="proximityDragZoneDistanceSliderAction:" target="Voe-Tx-rLC" id="YiI-66-YRd"/>

--- a/CCNStatusItem Example/CCNStatusItem Example/Info.plist
+++ b/CCNStatusItem Example/CCNStatusItem Example/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>395</string>
+	<string>398</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/CCNStatusItem/CCNStatusItem.h
+++ b/CCNStatusItem/CCNStatusItem.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSInteger, CCNStatusItemProximityDragStatus) {
     CCNProximityDragStatusExited
 };
 
-typedef void (^CCNStatusItemDropHandler)(CCNStatusItem *sharedItem);
+typedef void (^CCNStatusItemDropHandler)(CCNStatusItem *sharedItem, NSString *pasteboardType, NSArray *droppedObjects);
 typedef void (^CCNStatusItemProximityDragDetectionHandler)(CCNStatusItem *sharedItem, NSPoint eventLocation, CCNStatusItemProximityDragStatus proxymityDragStatus);
 
 
@@ -170,6 +170,7 @@ typedef void (^CCNStatusItemProximityDragDetectionHandler)(CCNStatusItem *shared
 @property (assign, nonatomic, getter=isProximityDragDetectionEnabled) BOOL proximityDragDetectionEnabled;
 @property (assign, nonatomic) NSInteger proximityDragZoneDistance;
 @property (copy, nonatomic) CCNStatusItemProximityDragDetectionHandler proximityDragDetectionHandler;
+@property (copy, nonatomic) NSArray *dropTypes;
 
 
 #pragma mark - Handling StatusItem Popover Layout

--- a/CCNStatusItem/CCNStatusItem.m
+++ b/CCNStatusItem/CCNStatusItem.m
@@ -29,6 +29,7 @@
 
 #import <Availability.h>
 #import "CCNStatusItem.h"
+#import "CCNStatusItemDropView.h"
 #import "CCNStatusItemWindowController.h"
 
 
@@ -95,6 +96,7 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
         self.appearsDisabled = NO;
         self.enabled = YES;
 
+        self.dropTypes = @[NSFilenamesPboardType];
         self.dropHandler = nil;
         self.proximityDragDetectionEnabled = NO;
         self.proximityDragZoneDistance = 23.0;
@@ -146,6 +148,20 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
     _proximityDragCollisionArea = [NSBezierPath bezierPathWithRoundedRect:collisionFrame xRadius:NSWidth(collisionFrame)/2 yRadius:NSHeight(collisionFrame)/2];
 }
 
+- (void)configureDropView {
+    if (self.dropHandler) {
+        NSStatusBarButton *button = self.statusItem.button;
+        NSRect buttonWindowFrame = button.window.frame;
+        NSRect statusItemFrame = NSMakeRect(0.0, 0.0, NSWidth(buttonWindowFrame), NSHeight(buttonWindowFrame));
+        CCNStatusItemDropView *dropView = [[CCNStatusItemDropView alloc] initWithFrame:statusItemFrame];
+        dropView.statusItem = self;
+        dropView.dropTypes = self.dropTypes;
+        dropView.dropHandler = self.dropHandler;
+        [button addSubview:dropView];
+        dropView.autoresizingMask = (NSViewWidthSizable | NSViewHeightSizable);
+    }
+}
+
 #pragma mark - Creating and Displaying a StatusBarItem
 
 - (void)presentStatusItemWithImage:(NSImage *)itemImage contentViewController:(NSViewController *)contentViewController {
@@ -158,6 +174,7 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
     self.dropHandler = dropHandler;
     [self configureWithImage:itemImage];
     [self configureProximityDragCollisionArea];
+    [self configureDropView];
     self.presentationMode = CCNStatusItemPresentationModeImage;
     self.statusItemWindowController = [[CCNStatusItemWindowController alloc] initWithConnectedStatusItem:self
                                                                                    contentViewController:contentViewController
@@ -174,6 +191,7 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
     self.dropHandler = dropHandler;
     [self configureWithView:itemView];
     [self configureProximityDragCollisionArea];
+    [self configureDropView];
     self.presentationMode = CCNStatusItemPresentationModeCustomView;
     self.statusItemWindowController = [[CCNStatusItemWindowController alloc] initWithConnectedStatusItem:self
                                                                                    contentViewController:contentViewController

--- a/CCNStatusItem/CCNStatusItemDropView.h
+++ b/CCNStatusItem/CCNStatusItemDropView.h
@@ -1,0 +1,40 @@
+//
+//  Created by David Sinclair on 2015-05-06.
+//  Copyright (c) 2015 cocoa:naut. All rights reserved.
+//
+
+/*
+ The MIT License (MIT)
+ Copyright © 2015 Frank Gregor, <phranck@cocoanaut.com>
+ http://cocoanaut.mit-license.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the “Software”), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import "CCNStatusItem.h"
+
+
+@interface CCNStatusItemDropView : NSView
+
+@property (nonatomic, weak) CCNStatusItem *statusItem;
+@property (nonatomic, copy) CCNStatusItemDropHandler dropHandler;
+@property (nonatomic, copy) NSArray *dropTypes;
+
+@end
+

--- a/CCNStatusItem/CCNStatusItemDropView.m
+++ b/CCNStatusItem/CCNStatusItemDropView.m
@@ -1,0 +1,87 @@
+//
+//  Created by David Sinclair on 2015-05-06.
+//  Copyright (c) 2015 cocoa:naut. All rights reserved.
+//
+
+/*
+ The MIT License (MIT)
+ Copyright © 2015 Frank Gregor, <phranck@cocoanaut.com>
+ http://cocoanaut.mit-license.org
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the “Software”), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+#import "CCNStatusItemDropView.h"
+
+
+@interface CCNStatusItemDropView ()
+
+@property (nonatomic, copy) NSArray *privateDropTypes;
+
+@end
+
+
+@implementation CCNStatusItemDropView
+
+- (NSArray *)dropTypes {
+    return self.privateDropTypes;
+}
+
+- (void)setDropTypes:(NSArray *)dropTypes {
+    self.privateDropTypes = dropTypes;
+    [self registerForDraggedTypes:self.privateDropTypes];
+}
+
+- (NSString *)dropTypeInPasteboardTypes:(NSArray *)pasteboardTypes {
+    for (NSString *type in self.dropTypes) {
+        if ([pasteboardTypes containsObject:type])
+        {
+            return type;
+        }
+    }
+    return nil;
+}
+
+- (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)sender {
+    NSPasteboard *pboard = [sender draggingPasteboard];
+    
+    if ([self dropTypeInPasteboardTypes:pboard.types]) {
+        return NSDragOperationCopy;
+    } else {
+        return NSDragOperationNone;
+    }
+}
+
+- (BOOL)performDragOperation:(id <NSDraggingInfo>)sender {
+    NSPasteboard *pboard = [sender draggingPasteboard];
+    NSString *type = [self dropTypeInPasteboardTypes:pboard.types];
+    
+    if (type) {
+        NSArray *items = [pboard propertyListForType:type];
+        
+        if (self.dropHandler) {
+            self.dropHandler(self.statusItem, type, items);
+            return YES;
+        }
+    }
+    return NO;
+}
+
+@end
+


### PR DESCRIPTION
When a drop handler is set, a CCNStatusItemDropView is added as a
subview of the status item button.  That receives drops, and passes the
dropped objects to the handler.  By default it accepts file paths, but
a dropTypes property can be set to accept other types.