### PR TITLE
Added a removeStatusItem method and a shouldShowHandler block.

### DIFF
--- a/CCNStatusItem Example/CCNStatusItem Example/Info.plist
+++ b/CCNStatusItem Example/CCNStatusItem Example/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>408</string>
+	<string>412</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/CCNStatusItem/CCNStatusItem.h
+++ b/CCNStatusItem/CCNStatusItem.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, CCNStatusItemProximityDragStatus) {
 
 typedef void (^CCNStatusItemDropHandler)(CCNStatusItem *sharedItem, NSString *pasteboardType, NSArray *droppedObjects);
 typedef void (^CCNStatusItemProximityDragDetectionHandler)(CCNStatusItem *sharedItem, NSPoint eventLocation, CCNStatusItemProximityDragStatus proxymityDragStatus);
+typedef BOOL (^CCNStatusItemShouldShowHandler)(CCNStatusItem *sharedItem);
 
 
 #pragma mark - CCNStatusItem
@@ -108,6 +109,11 @@ typedef void (^CCNStatusItemProximityDragDetectionHandler)(CCNStatusItem *shared
 - (void)updateContentViewController:(NSViewController *)contentViewController;
 
 /**
+ Removes the status item.
+ */
+- (void)removeStatusItem;
+
+/**
  Property that represents the underlying `NSStatusItem` to be displayed in the statusbar.
  */
 @property (strong, readonly) NSStatusItem *statusItem;
@@ -117,6 +123,12 @@ typedef void (^CCNStatusItemProximityDragDetectionHandler)(CCNStatusItem *shared
  */
 
 @property (copy, nonatomic) CCNStatusItemDropHandler dropHandler;
+
+/**
+ Property that represents the shouldShowHandler to be executed when the status item is clicked, if not nil.
+ */
+
+@property (copy, nonatomic) CCNStatusItemShouldShowHandler shouldShowHandler;
 
 
 #pragma mark - StatusBarItem and Popover presentation

--- a/CCNStatusItem/CCNStatusItem.m
+++ b/CCNStatusItem/CCNStatusItem.m
@@ -206,12 +206,24 @@ static NSString *const CCNStatusItemWindowConfigurationPinnedPath = @"windowConf
     [self.statusItemWindowController updateContenetViewController:contentViewController];
 }
 
+- (void)removeStatusItem {
+    if (self.statusItem) {
+        [[NSStatusBar systemStatusBar] removeStatusItem:self.statusItem];
+        
+        self.statusItem = nil;
+        self.presentationMode = CCNStatusItemPresentationModeUndefined;
+        self.isStatusItemWindowVisible = NO;
+        self.statusItemWindowController = nil;
+    }
+}
+
+
 #pragma mark - Button Action Handling
 
 - (void)handleStatusItemButtonAction:(id)sender {
     if (self.isStatusItemWindowVisible) {
         [self dismissStatusItemWindow];
-    } else {
+    } else if (!self.shouldShowHandler || self.shouldShowHandler(self)) {
         [self showStatusItemWindow];
     }
 }


### PR DESCRIPTION
The removeStatusItem method allows toggling the status item off
dynamically.  The shouldShowHandler allows dynamically deciding whether
or not to show the popover window (and perhaps doing something else
instead) when the status item is clicked.