### PR TITLE
Add limitation for window frame's Y

### DIFF
--- a/CCNStatusItem/CCNStatusItemWindowController.m
+++ b/CCNStatusItem/CCNStatusItemWindowController.m
@@ -94,7 +94,7 @@ typedef void (^CCNStatusItemWindowAnimationCompletion)(void);
 - (void)updateWindowFrame {
     CGRect statusItemRect = [[self.statusItemView.statusItem.button window] frame];
     CGRect windowFrame = NSMakeRect(NSMinX(statusItemRect) - NSWidth(self.window.frame) / 2 + NSWidth(statusItemRect) / 2,
-                                    NSMinY(statusItemRect) - NSHeight(self.window.frame) - self.windowConfiguration.windowToStatusItemMargin,
+                                    MIN(NSMinY(statusItemRect), [NSScreen mainScreen].frame.size.height) - NSHeight(self.window.frame) - self.windowConfiguration.windowToStatusItemMargin,
                                     self.window.frame.size.width,
                                     self.window.frame.size.height);
     [self.window setFrame:windowFrame display:YES];


### PR DESCRIPTION
In full screen mode, some times the statusItemRect may get a much further distance from the edge of the screen, which results in a Y origin much bigger then screen's top (varies on apps, but no problem when Xcode is in focus). In that case, window brought out by code will have part outside the screen. So a limitation for the window frame’s origin is necessary.